### PR TITLE
Fixed o(n) complexity in consolidate() (now o(2 log n))

### DIFF
--- a/fib-heap.py
+++ b/fib-heap.py
@@ -1,3 +1,5 @@
+import math
+
 
 class FibonacciHeap:
 
@@ -117,7 +119,7 @@ class FibonacciHeap:
     # combine root nodes of equal degree to consolidate the heap
     # by creating a list of unordered binomial trees
     def consolidate(self):
-        A = [None] * self.total_nodes
+        A = [None] * int(math.log(self.total_nodes) * 2)
         nodes = [w for w in self.iterate(self.root_list)]
         for w in range(0, len(nodes)):
             x = nodes[w]


### PR DESCRIPTION
Consolidate used an array of the size of total_nodes to work, while you only need an array of the size of max degree (Which can't go higher than 2*log n). This made extract_min unneccessarily complex on big graphs.

I was able to improve the runtime on my Prim algorithm from 510 seconds to 5.6 seconds on a graph with 100.000 nodes and 200.000 edges with this small change.